### PR TITLE
Remove scenario title metadata field

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,10 +44,6 @@ prose:
         field:
           element: hidden
           value: true
-      - name: "title"
-        field:
-          element: "text"
-          label: "Title"
       - name: "project"
         field:
           element: "text"


### PR DESCRIPTION
Should prevent renaming of scenarios via https://github.com/prose/prose/wiki/Prose-Configuration#post-titles
